### PR TITLE
Add docstring and __all__ for exports

### DIFF
--- a/src/kpop/__init__.py
+++ b/src/kpop/__init__.py
@@ -1,3 +1,15 @@
+"""Python k-pop library.
+
+This package lets you safely traverse complex expressions by wrapping
+values in a protective :class:`~kpop.core.Bubble`. Attribute access,
+item lookup and function calls are recorded and any exception is
+suppressed. Use :func:`~kpop.core.k` to start a chain and
+:func:`~kpop.core.kpop` to retrieve the final value (or a provided
+default) once evaluation is complete.
+"""
+
 from .core import Bubble, k, kpop
 
-__version__ = '0.1.0'
+__all__ = ["Bubble", "k", "kpop"]
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- document the package in `kpop.__init__`
- provide `__all__` to clarify exports

## Testing
- `python -m pip install -e .` *(fails: `invalid command 'bdist_wheel'`)*